### PR TITLE
breadcrumbs

### DIFF
--- a/jspm.config.js
+++ b/jspm.config.js
@@ -69,6 +69,7 @@ SystemJS.config({
   map: {
     "Hypercubed/d3-tip": "github:Hypercubed/d3-tip@master",
     "angular-animate": "npm:angular-animate@1.5.8",
+    "angular-breadcrumbs": "npm:angular-breadcrumbs@0.5.3",
     "angular-downloadsvg-directive": "npm:angular-downloadsvg-directive@0.2.0",
     "FileSaver": "github:eligrey/FileSaver.js@master",
     "URIjs": "npm:URIjs@1.16.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "gulp-task-listing": "^1.0.1",
     "gulp-template": "^4.0.0",
     "hydrolysis": "1.21.4",
-    "jspm": "0.17.0-beta.31",
+    "jspm": "^0.17.0-beta.31",
     "mkdirp": "^0.5.1",
     "require-dir": "^0.3.0",
     "run-sequence": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
       "URIjs": "npm:URIjs@^1.16.1",
       "_F": "github:Hypercubed/_F@^0.0.11",
       "angular-animate": "npm:angular-animate@1.5.8",
+      "angular-breadcrumbs": "npm:angular-breadcrumbs@^0.5.3",
       "angular-cookies": "npm:angular-cookies@^1.5.8",
       "angular-downloadsvg-directive": "npm:angular-downloadsvg-directive@0.2.0",
       "angular-growl": "npm:angular-growl-v2@^0.7.5",


### PR DESCRIPTION
Add  [angular-breadcrumbs](https://www.npmjs.com/package/angular-breadcrumbs) package from npm

Allows to create breadcrumbs:

* in route.js
```
// import the package
import breadcrumbs from 'angular-breadcrumbs';
[...]
// Add a label for your routes
.when('/', {
    label: 'Home',
    template: ...
[...]
// Work with parametric route
.when('/:project', {
    label: 'project',
    title: $routeParams => $routeParams.project,
[...]
// add the service as module dependency
export default angular
  .module('igR', ['igR', breadcrumbs])
[...]
```

* in each of your controller.js
```
// inject the service
controller.$inject = ['$routeParams', 'breadcrumbs'];
function controller($routeParams, breadcrumbs) {
  const $ctrl = this;

  // breadcrumbs pattern for parametric routes
  breadcrumbs.options = {
    project: $routeParams.project,
  };
  $ctrl.breadcrumbs = breadcrumbs;
```

* in each of template.html
```
<!-- add a breadcrumbs template-->
<div>
  <ol class="ab-nav breadcrumb">
      <li ng-repeat="breadcrumb in $ctrl.breadcrumbs.get() track by breadcrumb.path" ng-class="{ active: $last }">
        <a ng-if="!$last" ng-href="#{{ breadcrumb.path }}" ng-bind="breadcrumb.label" class="margin-right-xs"></a>
        <span ng-if="$last" ng-bind="breadcrumb.label"></span>
      </li>
  </ol>
</div>
```
